### PR TITLE
Value was not being passed to the label formatter as an array if present

### DIFF
--- a/dist/d3-funnel.js
+++ b/dist/d3-funnel.js
@@ -344,7 +344,7 @@ return /******/ (function(modules) { // webpackBootstrap
 						fill: _this2.colorizer.getBlockFill(block, index, _this2.fillType),
 						label: {
 							raw: label,
-							formatted: _this2.labelFormatter.format(label, count),
+							formatted: _this2.labelFormatter.format(label, block[1]),
 							color: _this2.colorizer.getLabelFill(block)
 						}
 					});

--- a/src/d3-funnel/d3-funnel.js
+++ b/src/d3-funnel/d3-funnel.js
@@ -251,7 +251,7 @@ class D3Funnel {
 				fill: this.colorizer.getBlockFill(block, index, this.fillType),
 				label: {
 					raw: label,
-					formatted: this.labelFormatter.format(label, count),
+					formatted: this.labelFormatter.format(label, block[1]),
 					color: this.colorizer.getLabelFill(block),
 				},
 			});


### PR DESCRIPTION
Values passed in an array with a pre-formatted string were not being passed to the label formatter, only the first value from the array.  
``` javascript
var data = [
    ['Teal',      [12000, 'USD 12,000']],
    ['Byzantium', [4000,  'USD 4,000']],
    ['Persimmon', [2500,  'USD 2,500']],
    ['Azure',     [1500,  'USD 1,500']],
];
```